### PR TITLE
MAID-1299

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
 raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints, unsafe_code,
 unused, unused_allocation, unused_attributes, unused_comparisons,
-unused_features, unused_parens, while_true)]
+unused_features, unused_parens, unused_mut, while_true)]
 
 #![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
 unused_qualifications, variant_size_differences)]


### PR DESCRIPTION
LINT check for "unused-mutable-variables" seems already implied by "unused"
bitcoin address: 13VH2zbF8ASaqJRtAGMHcNxm4Z6Bwdp3TU